### PR TITLE
Remove reserved IP from DO project

### DIFF
--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -73,5 +73,5 @@ resource "digitalocean_project" "this" {
   description = "A project to represent dracarys back end resources"
   purpose     = "Service or API"
   environment = var.environment
-  resources   = [digitalocean_droplet.api_server.urn, digitalocean_reserved_ip.this.urn, digitalocean_database_cluster.postgres.urn, digitalocean_database_cluster.redis.urn]
+  resources   = [digitalocean_droplet.api_server.urn, digitalocean_database_cluster.postgres.urn, digitalocean_database_cluster.redis.urn]
 }


### PR DESCRIPTION
Terraform had an error when creating the Project resource in DigitalOcean. I suspect it's due to the fact that Floating IPs are allowed in DO Projects, but not Reserved IPs (even though the docs claim they're functionally the same). 

This just removes the Reserved IP from the Project resource.