### PR TITLE
Remove UserData script from Droplet

### DIFF
--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -4,6 +4,30 @@ For the publicly hosted version of the Dracarys backend, we use a Terraform conf
 
 To see how to contribute to the infrastructure, see [CONTRIBUTING.md](../CONTRIBUTING.md).
 
+## Creating a new environment
+1. Create a new branch for the environment in GitHub
+2. Create a new workspace for the environment in Terraform Cloud linked to the branch created in step 1
+3. Add the necessary variables in the Terraform workspace (see [variables.tf](variables.tf) or the documentation below to see which variables to add), then apply the Terraform configuration to create the infrastructure in Digital Ocean
+4. SSH into the Droplet and the following commands to set up the environment:
+```
+# Install Node, NPM, and pm2
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.3/install.sh | bash
+
+# (follow instructions to add nvm to your path, or restart your shell)
+
+nvm install 16
+npm install pm2 -g
+echo "module.exports = {
+  apps : [{
+    name: 'dracarys',
+    script: 'app/dist/src/main.js',
+    watch: 'app'
+  }],
+};" > ecosystem.config.js
+mkdir app
+```
+**NOTE: it would be nice to automate this, but it's more difficult to do so in an Ubuntu UserData startup script, since the root user does not exist at the time the script runs, which interferes with the installation of nvm.**
+
 # Root Module Documentation
 <!-- BEGIN_TF_DOCS -->
 ## Requirements

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -32,15 +32,6 @@ resource "digitalocean_droplet" "api_server" {
   size     = var.droplet_size
   vpc_uuid = digitalocean_vpc.network.id
   ssh_keys = var.droplet_initial_ssh_keys
-  # Startup script to install node, npm, and pm2 to run the nest app
-  user_data = <<EOT
-#!/bin/sh
-
-sudo apt update -y
-sudo apt install nodejs -y
-sudo apt install npm -y
-npm install pm2 -g
-EOT
 }
 
 resource "digitalocean_reserved_ip" "this" {


### PR DESCRIPTION
Due to complications with installing NVM in a UserData script, I'm removing it entirely. From now on, when setting up a new environment, whoever does it will just have to run a few commands manually to do so.